### PR TITLE
Fix services display showing [object Object] on home page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -42,7 +42,7 @@ const HomePage = () => {
           </Heading>
           <Text lineHeight="1.8">{servicesIntro}</Text>
           <Text lineHeight="1.9" color="brand.accentMuted">
-            {services.slice(0, 4).join(' • ')}
+            {services.slice(0, 4).map(s => typeof s === 'string' ? s : s.label).join(' • ')}
           </Text>
           <InternalLink href="/services" px={0} fontWeight="600">
             View consultancy services


### PR DESCRIPTION
The services array contains mixed types (strings and objects with label/subItems).
The .join() call was rendering objects as [object Object]. Now extracts .label
from object entries before joining.

https://claude.ai/code/session_01VtXEB1UpETTY7C7yyQQRhm